### PR TITLE
Fix TypeError [ERR_INVALID_CALLBACK]: Callback must be a function

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -27,8 +27,7 @@ const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
 const printBuildError = require('react-dev-utils/printBuildError');
 
 // Let's monkey patch for now, to make RNVI works with RNW
-const babelrc = { presets: ['react-native'] };
-fs.writeFile('node_modules/react-native-vector-icons/.babelrc', JSON.stringify(babelrc) , 'utf-8');
+require('./patch');
 
 const measureFileSizesBeforeBuild =
   FileSizeReporter.measureFileSizesBeforeBuild;

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+// Update .babelrc file
+const babelrc = { presets: ['react-native'] };
+fs.writeFile('node_modules/react-native-vector-icons/.babelrc', JSON.stringify(babelrc), 'utf8', (err) => {
+  if (err) throw err;
+  console.log('The file has been updated 🐺');
+});

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -32,8 +32,7 @@ const config = require('../config/webpack.config.dev');
 const createDevServerConfig = require('../config/webpackDevServer.config');
 
 // Let's monkey patch for now, to make RNVI works with RNW
-const babelrc = { presets: ['react-native'] };
-fs.writeFile('node_modules/react-native-vector-icons/.babelrc', JSON.stringify(babelrc) , 'utf-8');
+require('./patch');
 
 const useYarn = fs.existsSync(paths.yarnLockFile);
 const isInteractive = process.stdout.isTTY;


### PR DESCRIPTION
Update use of `fs.writeFile` based on the [docs](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).

Closes #5 